### PR TITLE
Update imports to use full path

### DIFF
--- a/ckanext/csrf_filter/anti_csrf.py
+++ b/ckanext/csrf_filter/anti_csrf.py
@@ -18,7 +18,7 @@ import time
 import six
 from six.moves.urllib.parse import quote, urlparse
 
-from request_helpers import RequestHelper
+from ckanext.csrf_filter.request_helpers import RequestHelper
 
 LOG = getLogger(__name__)
 

--- a/ckanext/csrf_filter/anti_csrf_pylons.py
+++ b/ckanext/csrf_filter/anti_csrf_pylons.py
@@ -11,7 +11,7 @@ from ckan.common import response
 from ckan.lib import base
 from ckan.plugins import toolkit
 
-import anti_csrf
+from ckanext.csrf_filter import anti_csrf
 
 
 RAW_RENDER_JINJA = base.render_jinja2

--- a/ckanext/csrf_filter/plugin.py
+++ b/ckanext/csrf_filter/plugin.py
@@ -7,7 +7,7 @@ from logging import getLogger
 from ckan.plugins import toolkit, SingletonPlugin, implements, \
     IConfigurable, IRoutes, IBlueprint, IMiddleware
 
-import anti_csrf
+from ckanext.csrf_filter import anti_csrf
 
 
 if toolkit.check_ckan_version(min_version='2.8.0'):
@@ -58,7 +58,7 @@ class CSRFFilterPlugin(SingletonPlugin):
         """ Monkey-patch Pylons after routing is set up.
         """
         try:
-            import anti_csrf_pylons
+            from ckanext.csrf_filter import anti_csrf_pylons
             anti_csrf_pylons.intercept()
         except Exception:
             LOG.warn("Unable to load Pylons support. Pylons routes will not be protected.")

--- a/ckanext/csrf_filter/test_anti_csrf.py
+++ b/ckanext/csrf_filter/test_anti_csrf.py
@@ -6,7 +6,7 @@
 import re
 import unittest
 
-import anti_csrf
+from ckanext.csrf_filter import anti_csrf
 import six
 
 NUMBER_FIELDS = re.compile(r'(![0-9]+)/([0-9]+)/')

--- a/ckanext/csrf_filter/test_token_protected_friendlyform.py
+++ b/ckanext/csrf_filter/test_token_protected_friendlyform.py
@@ -5,8 +5,8 @@
 
 import unittest
 
-import anti_csrf
-import token_protected_friendlyform
+from ckanext.csrf_filter import anti_csrf
+from ckanext.csrf_filter import token_protected_friendlyform
 import six
 
 

--- a/ckanext/csrf_filter/token_protected_friendlyform.py
+++ b/ckanext/csrf_filter/token_protected_friendlyform.py
@@ -6,7 +6,7 @@ from logging import getLogger
 from repoze.who.plugins import friendlyform
 from webob import Request
 
-import anti_csrf
+from ckanext.csrf_filter import anti_csrf
 
 LOG = getLogger(__name__)
 


### PR DESCRIPTION
CKAN 2.9.3 with Python 3.7 was not happy with the
local import style, unable to find the modules.

I think you can also use `import .anti_csrf` as well, what do you prefer @ThrawnCA ?