### PR TITLE
[QOL-8392] ensure response body is of a type we can process

### DIFF
--- a/ckanext/csrf_filter/anti_csrf.py
+++ b/ckanext/csrf_filter/anti_csrf.py
@@ -357,7 +357,7 @@ def insert_token(html, token, request=None):
             separator = '?'
         return link_match.group(1) + separator + TOKEN_FIELD_NAME + '=' + token + link_match.group(3)
 
-    html = POST_FORM.sub(insert_form_token, six.text_type(html))
+    html = POST_FORM.sub(insert_form_token, six.ensure_text(html))
     html = CONFIRM_LINK.sub(insert_link_token, html)
     html = CONFIRM_LINK_REVERSED.sub(insert_link_token, html)
     return html


### PR DESCRIPTION
Without this, CKAN 2.9 can give an error:

        [Tue Nov 16 15:24:53.236950 2021] [:error] [pid 25176]   File "/mnt/local_data/ckan_venv/src/ckanext-csrf-filter/ckanext/csrf_filter/anti_csrf
        .py", line 360, in insert_token
        [Tue Nov 16 15:24:53.236953 2021] [:error] [pid 25176]     html = POST_FORM.sub(insert_form_token, six.text_type(html))
        [Tue Nov 16 15:24:53.236955 2021] [:error] [pid 25176] UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 6152: ordinal not 
        in range(128)