### PR TITLE
[QOL-8392] gracefully handle contexts with no response object or non-HTML response type

### DIFF
--- a/ckanext/csrf_filter/anti_csrf_pylons.py
+++ b/ckanext/csrf_filter/anti_csrf_pylons.py
@@ -22,7 +22,9 @@ def _render_jinja(template_name, extra_vars=None):
     """ Wrap the Jinja rendering function to inject tokens on HTML responses.
     """
     html = RAW_RENDER_JINJA(template_name, extra_vars)
-    if anti_csrf.is_logged_in():
+    if template_name.endswith('.html') \
+            and 'set_cookie' in dir(response) \
+            and anti_csrf.is_logged_in():
         token = anti_csrf.get_response_token(response)
         html = anti_csrf.insert_token(html, token)
     return html


### PR DESCRIPTION
Eg email notifications on the job queue need to render templates, but have no response object and don't need CSRF token injection.