### PR TITLE
[QOL-8392] ensure aborts are returned

### DIFF
--- a/ckanext/csrf_filter/anti_csrf_pylons.py
+++ b/ckanext/csrf_filter/anti_csrf_pylons.py
@@ -36,7 +36,7 @@ def _before_controller(obj, action, **params):
     RAW_BEFORE(obj, action)
 
     if not anti_csrf.check_csrf():
-        toolkit.abort(403, "Your form submission could not be validated")
+        return toolkit.abort(403, "Your form submission could not be validated")
 
 
 def intercept():

--- a/ckanext/csrf_filter/plugin.py
+++ b/ckanext/csrf_filter/plugin.py
@@ -79,7 +79,7 @@ class CSRFFilterPlugin(SingletonPlugin):
             """ Abort invalid Flask requests based on CSRF token.
             """
             if not anti_csrf.check_csrf():
-                toolkit.abort(403, "Your form submission could not be validated")
+                return toolkit.abort(403, "Your form submission could not be validated")
 
         @blueprint.after_app_request
         def set_csrf_token(response):


### PR DESCRIPTION
- Pylons automatically handles them, but Flask needs them to be returned