### PR TITLE
QOLSVC-978 add CKAN 2.10 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: [2.9, 2.9-py2, 2.8]
+        ckan-version: ["2.10", 2.9, 2.9-py2, 2.8]
       fail-fast: true
 
     name: CKAN ${{ matrix.ckan-version }}

--- a/ckanext/csrf_filter/plugin.py
+++ b/ckanext/csrf_filter/plugin.py
@@ -10,7 +10,7 @@ from ckan.plugins import implements, toolkit
 from ckanext.csrf_filter import anti_csrf
 
 
-if toolkit.check_ckan_version(min_version='2.8.0'):
+if toolkit.check_ckan_version('2.8'):
     from flask import Blueprint, Request
     from werkzeug.datastructures import MultiDict, ImmutableMultiDict
 

--- a/ckanext/csrf_filter/plugin.py
+++ b/ckanext/csrf_filter/plugin.py
@@ -4,8 +4,8 @@
 
 from logging import getLogger
 
-from ckan.plugins import toolkit, SingletonPlugin, implements, \
-    IConfigurable, IRoutes, IBlueprint, IMiddleware
+from ckan import plugins
+from ckan.plugins import implements, toolkit
 
 from ckanext.csrf_filter import anti_csrf
 
@@ -34,15 +34,16 @@ if toolkit.check_ckan_version(min_version='2.8.0'):
 LOG = getLogger(__name__)
 
 
-class CSRFFilterPlugin(SingletonPlugin):
+class CSRFFilterPlugin(plugins.SingletonPlugin):
     """ Inject CSRF tokens into HTML responses,
     and validate them on applicable requests.
     """
-    implements(IConfigurable, inherit=True)
-    implements(IRoutes, inherit=True)
+    implements(plugins.IConfigurable, inherit=True)
+    if not toolkit.check_ckan_version('2.9'):
+        implements(plugins.IRoutes, inherit=True)
     if toolkit.check_ckan_version(min_version='2.8.0'):
-        implements(IBlueprint, inherit=True)
-        implements(IMiddleware, inherit=True)
+        implements(plugins.IBlueprint, inherit=True)
+        implements(plugins.IMiddleware, inherit=True)
 
     # IConfigurable
 

--- a/ckanext/csrf_filter/test_anti_csrf.py
+++ b/ckanext/csrf_filter/test_anti_csrf.py
@@ -4,11 +4,15 @@
 '''
 
 import re
+import six
 import unittest
-from webob import Request
 
 from ckanext.csrf_filter import anti_csrf
-import six
+
+try:
+    from ckanext.csrf_filter.plugin import CSRFAwareRequest as Request
+except Exception:
+    from webob import Request
 
 NUMBER_FIELDS = re.compile(r'(![0-9]+)/([0-9]+)/')
 STUB_TOKEN = 'some_token_or_other'


### PR DESCRIPTION
Avoid referencing IRoutes and WebOb on CKAN 2.10+