### PR TITLE
[QOLSVC-1241] stop login page from being cached

### DIFF
--- a/ckanext/csrf_filter/plugin.py
+++ b/ckanext/csrf_filter/plugin.py
@@ -8,6 +8,7 @@ from ckan import plugins
 from ckan.plugins import implements, toolkit
 
 from ckanext.csrf_filter import anti_csrf
+from ckanext.csrf_filter.request_helpers import RequestHelper
 
 
 if toolkit.check_ckan_version('2.8'):
@@ -39,6 +40,7 @@ class CSRFFilterPlugin(plugins.SingletonPlugin):
     and validate them on applicable requests.
     """
     implements(plugins.IConfigurable, inherit=True)
+    implements(plugins.IAuthenticator, inherit=True)
     if not toolkit.check_ckan_version('2.9'):
         implements(plugins.IRoutes, inherit=True)
     if toolkit.check_ckan_version(min_version='2.8.0'):
@@ -52,6 +54,13 @@ class CSRFFilterPlugin(plugins.SingletonPlugin):
         """
         self.config = config
         anti_csrf.configure(config)
+
+    # IAuthenticator
+
+    def login(self):
+        request = RequestHelper()
+        request.get_environ()['__no_cache__'] = True
+        return None
 
     # IRoutes
 

--- a/ckanext/csrf_filter/request_helpers.py
+++ b/ckanext/csrf_filter/request_helpers.py
@@ -9,8 +9,8 @@ class RequestHelper():
         if request:
             self.request = request
         else:
-            import ckan.common
-            self.request = ckan.common.request
+            from ckan.plugins import toolkit
+            self.request = toolkit.request
 
     def get_path(self):
         """ Get the request path, without query string.


### PR DESCRIPTION
- If we are preventing Login CSRF, then there will be a token set in the login form, which mustn't be cached lest we get errors upon logging out and back in.