### PR TITLE
SameSite Config Option for Cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ replace the FriendlyForm plugin in `who.ini` with a token-aware version:
     use = ckanext.csrf_filter.token_protected_friendlyform:TokenProtectedFriendlyFormPlugin
     ```
 
+1. Optional: To set token cookie [SameSite attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value), set ``ckanext.csrf_filter.same_site`` setting in your CKAN config file. By default, the SameSite attribute will be ``None``. Supported values:
+
+    * Strict
+    * Lax
+    * None
+
 1. Restart CKAN. Eg if you've deployed CKAN with Apache on Ubuntu:
 
     ```

--- a/ckanext/csrf_filter/anti_csrf.py
+++ b/ckanext/csrf_filter/anti_csrf.py
@@ -64,6 +64,7 @@ def configure(config):
     """ Configure global values for the filter.
     """
     global secure_cookies
+    global same_site
     global secret_key
     global token_expiry_age
     global token_renewal_age
@@ -74,6 +75,10 @@ def configure(config):
     else:
         LOG.warning("Site %s is not secure! CSRF tokens may be exposed!", site_url)
         secure_cookies = False
+
+    same_site = config.get('ckanext.csrf_filter.same_site', 'None')
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
+    assert same_site in ['Strict', 'Lax', 'None']
 
     key_fields = ['ckanext.csrf_filter.secret_key',
                   'beaker.session.secret',
@@ -311,7 +316,7 @@ def _get_digest(message):
 def _set_response_token_cookie(token, response):
     """ Add a generated token cookie to the HTTP response.
     """
-    response.set_cookie(TOKEN_FIELD_NAME, token, secure=secure_cookies, httponly=True)
+    response.set_cookie(TOKEN_FIELD_NAME, token, secure=secure_cookies, httponly=True, samesite=same_site)
 
 
 def create_response_token():

--- a/ckanext/csrf_filter/anti_csrf.py
+++ b/ckanext/csrf_filter/anti_csrf.py
@@ -77,7 +77,7 @@ def configure(config):
         secure_cookies = False
 
     same_site = config.get('ckanext.csrf_filter.same_site', 'None')
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value
     assert same_site in ['Strict', 'Lax', 'None']
 
     key_fields = ['ckanext.csrf_filter.secret_key',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.0.1-SNAPSHOT'
+version = '1.1.6'
 
 setup(
     name='ckanext-csrf-filter',


### PR DESCRIPTION
Adds `ckanext.csrf_filter.same_site` config option which defaults to `'None'` and uses it in setting the token cookie. Asserts the allowed values of 'Strict', 'Lax', and 'None'

This should solve the issue: https://github.com/qld-gov-au/ckanext-csrf-filter/issues/28