### PR TITLE
Allow Response Streams

### DIFF
--- a/ckanext/csrf_filter/plugin.py
+++ b/ckanext/csrf_filter/plugin.py
@@ -3,6 +3,7 @@
 """
 
 from logging import getLogger
+from types import GeneratorType
 
 from ckan import plugins
 from ckan.plugins import implements, toolkit
@@ -95,6 +96,9 @@ class CSRFFilterPlugin(plugins.SingletonPlugin):
         def set_csrf_token(response):
             """ Apply a CSRF token to all response bodies.
             """
+            if isinstance(getattr(response, 'response', None), GeneratorType):
+                return response
+
             response.direct_passthrough = False
             anti_csrf.apply_token(response)
             return response


### PR DESCRIPTION
feat(blueprint): allow response streams;

- Do not insert html if the response type is a generator stream.


The `set_csrf_token` will always try to insert the hidden token field into forms from the response data. However, this breaks response streams. As by default all HTML templates are NOT streamed in CKAN, I think it is safe to just not do the insertion of the hidden token field for generator responses. This mainly affects big data being streamed to a user, like a large file download.

It is possible for developers to setup template streams for super, super large HTML pages. But I think this would be such a niche case that we do not need to support here? People shouldn't have such large HTML pages that they would need to stream them to the user.