### PR TITLE
[QOLSVC-3186] preserve CSRF token in API token deletion form

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ on: [push]
 
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Install requirements
@@ -25,12 +25,12 @@ jobs:
       fail-fast: true
 
     name: CKAN ${{ matrix.ckan-version }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container:
       image: openknowledge/ckan-dev:${{ matrix.ckan-version }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install requirements
       run: |

--- a/ckanext/csrf_filter/plugin.py
+++ b/ckanext/csrf_filter/plugin.py
@@ -39,6 +39,7 @@ class CSRFFilterPlugin(plugins.SingletonPlugin):
     """ Inject CSRF tokens into HTML responses,
     and validate them on applicable requests.
     """
+    implements(plugins.IConfigurer)
     implements(plugins.IConfigurable, inherit=True)
     implements(plugins.IAuthenticator, inherit=True)
     if not toolkit.check_ckan_version('2.9'):
@@ -46,6 +47,11 @@ class CSRFFilterPlugin(plugins.SingletonPlugin):
     if toolkit.check_ckan_version(min_version='2.8.0'):
         implements(plugins.IBlueprint, inherit=True)
         implements(plugins.IMiddleware, inherit=True)
+
+    # IConfigurer
+
+    def update_config(self, config_):
+        toolkit.add_template_directory(config_, 'templates')
 
     # IConfigurable
 

--- a/ckanext/csrf_filter/templates/user/snippets/api_token_list.html
+++ b/ckanext/csrf_filter/templates/user/snippets/api_token_list.html
@@ -1,0 +1,15 @@
+{% ckan_extends %}
+
+{% block token_cell_actions %}
+<td>
+  {% set action = h.url_for("user.api_token_revoke", id=user['name'], jti=token['id']) %}
+  <form action="{{ action }}" method="POST">
+    {{ h.csrf_input() }}
+    <div class="btn-group">
+      <button type="submit" href="{{ action }}" class="btn btn-danger btn-sm" title="{{ _('Revoke') }}" data-module="confirm-action" data-module-with-data=true>
+        <i class="fa fa-times"></i>
+      </button>
+    </div>
+  </form>
+</td>
+{% endblock token_cell_actions %}


### PR DESCRIPTION
- The confirm-action module drops form fields by default, we need to retain them