### PR TITLE
[QOLSVC-3914] exclude logout URL from CSRF protection

### DIFF
--- a/ckanext/csrf_filter/anti_csrf.py
+++ b/ckanext/csrf_filter/anti_csrf.py
@@ -96,7 +96,7 @@ def configure(config):
     token_expiry_age = 60 * config.get('ckanext.csrf_filter.token_expiry_minutes', 30)
     token_renewal_age = 60 * config.get('ckanext.csrf_filter.token_renewal_minutes', 10)
 
-    exempt_rules = [re.compile(r'^/+api/.*')]
+    exempt_rules = [re.compile(r'^/+api/.*'), re.compile(r'^/user/_logout.*')]
     custom_exempt_rules = config.get('ckanext.csrf_filter.exempt_rules', None)
     if custom_exempt_rules:
         for rule in json.loads(custom_exempt_rules):

--- a/ckanext/csrf_filter/test_anti_csrf.py
+++ b/ckanext/csrf_filter/test_anti_csrf.py
@@ -276,6 +276,7 @@ class TestAntiCsrfFilter(unittest.TestCase):
         config['ckanext.csrf_filter.exempt_rules'] = '["^/datatables/ajax/.*", "/datatables/filtered-download/.*"]'
         expected = [
             '^/+api/.*',
+            '^/user/_logout.*',
             '^/datatables/ajax/.*',
             '/datatables/filtered-download/.*'
         ]


### PR DESCRIPTION
- Logging out doesn't need to be protected like logging in does, and the token can be corrupted by page caching.

@JVickery-TBS Thanks for making it easy to add new exclusions.